### PR TITLE
Reviews counter & Clickable Manga on Bookshelf Page

### DIFF
--- a/public/javascripts/add-review.js
+++ b/public/javascripts/add-review.js
@@ -20,6 +20,10 @@ window.addEventListener('DOMContentLoaded', e => {
 
     const data = await res.json();
     if (data.message === "Create Successful") {
+      // update review counter
+      const reviewCount = document.getElementById("review-counter");
+      reviewCount.innerText = parseInt(reviewCount.innerText, 10) + 1;
+
       form.reset()
       // If the review was created, create the review html elements and show it on the screen
       const editReviewBtn = document.createElement("button");
@@ -124,9 +128,12 @@ window.addEventListener('DOMContentLoaded', e => {
         const data = await res.json();
 
         if (data.message === "Delete Successful") {
-            reviewBoxEle.remove();
-            editReviewBtn.remove();
-            deleteReviewBtn.remove();
+          // update review count
+          const reviewCount = document.getElementById("review-counter");
+          reviewCount.innerText = parseInt(reviewCount.innerText, 10) - 1;
+          reviewBoxEle.remove();
+          editReviewBtn.remove();
+          deleteReviewBtn.remove();
         }
       });
 

--- a/public/javascripts/delete-review.js
+++ b/public/javascripts/delete-review.js
@@ -13,11 +13,15 @@ window.addEventListener('DOMContentLoaded', e => {
       const data = await res.json();
 
       if (data.message === "Delete Successful") {
-          const reviewBox = document.getElementById(`box-${reviewId}`);
-          const editReviewBtn = document.getElementById(`edit-${reviewId}`);
-          reviewBox.remove();
-          editReviewBtn.remove();
-          btn.remove();
+        // update review count
+        const reviewCount = document.getElementById("review-counter");
+        reviewCount.innerText = parseInt(reviewCount.innerText, 10) - 1;
+
+        const reviewBox = document.getElementById(`box-${reviewId}`);
+        const editReviewBtn = document.getElementById(`edit-${reviewId}`);
+        reviewBox.remove();
+        editReviewBtn.remove();
+        btn.remove();
       }
     });
   }

--- a/views/bookshelves.pug
+++ b/views/bookshelves.pug
@@ -33,7 +33,8 @@ block content
                         each manga in bookshelf.Mangas
                             div(id=`manga-box-${manga.id}` class="manga-box")
                                 div
-                                    img(src=manga.imgSrc, alt=`image of ${manga.title}'s manga cover` id="manga-image")
+                                    a(href=`/mangas/${manga.id}`)
+                                        img(src=manga.imgSrc, alt=`image of ${manga.title}'s manga cover` id="manga-image")
                                 div(id="manga-title")
                                     label(class="title-label" for="manga-title") Title
                                     p= manga.title

--- a/views/manga-detail.pug
+++ b/views/manga-detail.pug
@@ -43,7 +43,7 @@ block content
         button(class="submitReview" type="submit") Submit
 
       div(class="reviews")
-        h2(id="review-heading") Reviews (#{reviews.length})
+        h2(id="review-heading") Reviews (<span id="review-counter">#{reviews.length}</span>)
         div(class="reviewbox")
           ul(id="reviewsContainer")
             each review in reviews


### PR DESCRIPTION
- Made changes to the manga-detail pug: wrapped the review count in a span tag to grab it by id
- Dynamically updated the review count span in add-review.js and delete-review.js to increment and decrement
- Changed bookshelves.pug to make the image of the manga clickable => leading the user to that specific manga's detail page